### PR TITLE
fix(vies-response): fix formatting inconsistencies in vies_response fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ iex(1)> ExVatcheck.check("GB333289454")
     address: "BC0 B1 D1 BROADCAST CENTRE\nWHITE CITY PLACE\n201 WOOD LANE\nLONDON\n\nW12 7TP",
     country_code: "GB",
     name: "BRITISH BROADCASTING CORPORATION",
-    request_date: "2019-04-06+02:00",
+    request_date: "2019-04-06",
     valid: true,
     vat_number: "333289454"
   }

--- a/lib/ex_vatcheck/vies_client/xml_parser.ex
+++ b/lib/ex_vatcheck/vies_client/xml_parser.ex
@@ -8,8 +8,8 @@ defmodule ExVatcheck.VIESClient.XMLParser do
           vat_number: binary,
           request_date: binary,
           valid: boolean,
-          name: binary,
-          address: binary
+          name: binary | nil,
+          address: binary | nil
         }
 
   @check_vat_service_url SweetXml.sigil_x(
@@ -95,17 +95,25 @@ defmodule ExVatcheck.VIESClient.XMLParser do
     end
   end
 
-  @spec format_fields(response) :: response
+  @spec format_fields(map) :: response
   defp format_fields(body) do
     %{
-      country_code: to_string(body.country_code),
-      vat_number: to_string(body.vat_number),
-      request_date: to_string(body.request_date),
+      country_code: format_field(body.country_code),
+      vat_number: format_field(body.vat_number),
+      request_date: body.request_date |> format_field() |> format_date(),
       valid: body.valid == 'true',
-      name: body.name |> to_string(),
-      address: body.address |> to_string()
+      name: format_field(body.name),
+      address: format_field(body.address)
     }
   end
+
+  @spec format_field(charlist | nil) :: binary | nil
+  defp format_field(nil), do: nil
+  defp format_field(charlist), do: to_string(charlist)
+
+  @spec format_date(binary) :: binary
+  defp format_date(<<date::binary-size(10), "+", _time::binary-size(5)>>), do: date
+  defp format_date(date), do: date
 
   @spec format_fault(binary) :: binary
   defp format_fault(fault) do

--- a/test/ex_vatcheck/vies_client/xml_parser_test.exs
+++ b/test/ex_vatcheck/vies_client/xml_parser_test.exs
@@ -55,7 +55,7 @@ defmodule ExVatcheck.VIESClient.XMLParserTest do
       expected = %{
         country_code: "BE",
         vat_number: "0829071668",
-        request_date: "2016-01-16+01:00",
+        request_date: "2016-01-16",
         valid: true,
         name: "SPRL BIGUP",
         address: "RUE LONGUE 93 1320 BEAUVECHAIN"
@@ -83,10 +83,66 @@ defmodule ExVatcheck.VIESClient.XMLParserTest do
       expected = %{
         country_code: "BE",
         vat_number: "123123123",
-        request_date: "2016-01-16+01:00",
+        request_date: "2016-01-16",
         valid: false,
         name: "---",
         address: "---"
+      }
+
+      assert XMLParser.parse_response(response) == {:ok, expected}
+    end
+
+    test "correctly keeps nil values when present in checkVat response" do
+      response = """
+      <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+        <soap:Body>
+          <checkVatResponse xmlns="urn:ec.europa.eu:taxud:vies:services:checkVat:types">
+            <countryCode>BG</countryCode>
+            <vatNumber>451158821</vatNumber>
+            <requestDate>2016-01-16+01:00</requestDate>
+            <valid>false</valid>
+            <name></name>
+            <address></address>
+          </checkVatResponse>
+        </soap:Body>
+      </soap:Envelope>
+      """
+
+      expected = %{
+        country_code: "BG",
+        vat_number: "451158821",
+        request_date: "2016-01-16",
+        valid: false,
+        name: nil,
+        address: nil
+      }
+
+      assert XMLParser.parse_response(response) == {:ok, expected}
+    end
+
+    test "gracefully handles unexpected date formats" do
+      response = """
+      <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+        <soap:Body>
+          <checkVatResponse xmlns="urn:ec.europa.eu:taxud:vies:services:checkVat:types">
+            <countryCode>BG</countryCode>
+            <vatNumber>451158821</vatNumber>
+            <requestDate>2016-01</requestDate>
+            <valid>false</valid>
+            <name></name>
+            <address></address>
+          </checkVatResponse>
+        </soap:Body>
+      </soap:Envelope>
+      """
+
+      expected = %{
+        country_code: "BG",
+        vat_number: "451158821",
+        request_date: "2016-01",
+        valid: false,
+        name: nil,
+        address: nil
       }
 
       assert XMLParser.parse_response(response) == {:ok, expected}

--- a/test/ex_vatcheck/vies_client_test.exs
+++ b/test/ex_vatcheck/vies_client_test.exs
@@ -49,7 +49,7 @@ defmodule ExVatcheck.VIESClientTest do
       expected = %{
         country_code: "GB",
         vat_number: "333289454",
-        request_date: "2016-01-16+01:00",
+        request_date: "2016-01-16",
         valid: true,
         name: "BRITISH BROADCASTING CORPORATION",
         address: "BC0 B1 D1 BROADCAST CENTRE\nWHITE CITY PLACE\n201 WOOD LANE\nLONDON\n\nW12 7TP"
@@ -68,7 +68,7 @@ defmodule ExVatcheck.VIESClientTest do
       expected = %{
         country_code: "GB",
         vat_number: "123123123",
-        request_date: "2016-01-16+01:00",
+        request_date: "2016-01-16",
         valid: false,
         name: "---",
         address: "---"

--- a/test/ex_vatcheck_test.exs
+++ b/test/ex_vatcheck_test.exs
@@ -10,7 +10,7 @@ defmodule ExVatcheckTest do
   @valid_vat_response %{
     country_code: "GB",
     vat_number: "333289454",
-    request_date: "2016-01-16+01:00",
+    request_date: "2016-01-16",
     valid: true,
     name: "BRITISH BROADCASTING CORPORATION",
     address: "BC0 B1 D1 BROADCAST CENTRE\nWHITE CITY PLACE\n201 WOOD LANE\nLONDON\n\nW12 7TP"
@@ -19,7 +19,7 @@ defmodule ExVatcheckTest do
   @invalid_vat_response %{
     country_code: "GB",
     vat_number: "123123123",
-    request_date: "2016-01-16+01:00",
+    request_date: "2016-01-16",
     valid: false,
     name: "---",
     address: "---"


### PR DESCRIPTION
### Changes

- [x] Keeps `vies_response.name` and `vies_response.address` fields as `nil` instead of coercing to `""` when they are not present.
- [x] Removes hours and minutes from the `vies_response.request_date` field.