### PR TITLE
fix(normalize): use normalized vat for validation

### DIFF
--- a/lib/ex_vatcheck.ex
+++ b/lib/ex_vatcheck.ex
@@ -15,8 +15,10 @@ defmodule ExVatcheck do
   Returns an `ExVatcheck.VAT.t()` struct.
   """
   def check(vat) do
-    if vat |> VAT.normalize() |> Countries.valid_format?() do
-      validate(vat)
+    normalized_vat = VAT.normalize(vat)
+
+    if Countries.valid_format?(normalized_vat) do
+      validate(normalized_vat)
     else
       %VAT{}
     end

--- a/test/ex_vatcheck_test.exs
+++ b/test/ex_vatcheck_test.exs
@@ -76,5 +76,20 @@ defmodule ExVatcheckTest do
     test "returns empty struct if country regex not matched" do
       assert ExVatcheck.check("XX123456789") == %VAT{}
     end
+
+    test "gracefully handles non-alphanumeric characters" do
+      expected = %VAT{
+        valid: false,
+        exists: false,
+        vies_available: true,
+        vies_response: @invalid_vat_response
+      }
+
+      stub(HTTPoison, :post, fn _, _ ->
+        {:ok, %HTTPoison.Response{body: VIESResponses.invalid_vat_response()}}
+      end)
+
+      assert ExVatcheck.check("'GB123123123[]'") == expected
+    end
   end
 end


### PR DESCRIPTION
### Changes

Fixes a bug where we would passing the normalized VAT to `ExVatcheck.validate/1`. This caused issues when non-alphanumeric characters are passed in.