### PR TITLE
Update url to https to avoid invalid XML redirect

### DIFF
--- a/lib/ex_vatcheck/vies_client.ex
+++ b/lib/ex_vatcheck/vies_client.ex
@@ -6,7 +6,7 @@ defmodule ExVatcheck.VIESClient do
 
   alias ExVatcheck.VIESClient.XMLParser
 
-  @wsdl_url "http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl"
+  @wsdl_url "https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl"
 
   defstruct [:url]
 


### PR DESCRIPTION
Updates the `@wsdl_url` module attribute in `VIESClient` to use the updated https value. This avoids a redirect response that contains invalid XML that the parser was having trouble with.