### PR TITLE
0.1.4 - Update URL to use https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+#### 0.1.4 (2020-03-19)
+
+##### Bug Fixes
+
+* **vies-client:** Update url to https to avoid invalid XML redirect ([#5](https://github.com/taxjar/ex_vatcheck/pull/5))
+
 #### 0.1.3 (2019-05-10)
 
 ##### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ by adding `ex_vatcheck` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:ex_vatcheck, "~> 0.1.0"}
+    {:ex_vatcheck, "~> 0.1.4"}
   ]
 end
 ```

--- a/lib/ex_vatcheck/vies_client.ex
+++ b/lib/ex_vatcheck/vies_client.ex
@@ -6,7 +6,7 @@ defmodule ExVatcheck.VIESClient do
 
   alias ExVatcheck.VIESClient.XMLParser
 
-  @wsdl_url "http://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl"
+  @wsdl_url "https://ec.europa.eu/taxation_customs/vies/checkVatService.wsdl"
 
   defstruct [:url]
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExVatcheck.MixProject do
   def project do
     [
       app: :ex_vatcheck,
-      version: "0.1.3",
+      version: "0.1.4",
       elixir: "~> 1.4",
       name: "ExVatcheck",
       elixirc_paths: elixirc_paths(Mix.env()),


### PR DESCRIPTION
Updates the `@wsdl_url` module attribute in `VIESClient` to use the updated https value. This avoids a redirect response that contains invalid XML that the parser was having trouble with.