### PR TITLE
Ensure VIES client URL is using https

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+#### 0.1.5 (2020-03-19)
+
+##### Bug Fixes
+
+* **vies-client:** Ensure client url is using https ([#7](https://github.com/taxjar/ex_vatcheck/pull/7))
+
 #### 0.1.4 (2020-03-19)
 
 ##### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ by adding `ex_vatcheck` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:ex_vatcheck, "~> 0.1.4"}
+    {:ex_vatcheck, "~> 0.1.5"}
   ]
 end
 ```

--- a/lib/ex_vatcheck/countries.ex
+++ b/lib/ex_vatcheck/countries.ex
@@ -81,7 +81,7 @@ defmodule ExVatcheck.Countries do
   def valid_format?(<<country::binary-size(2), _::binary>>) when country not in @countries,
     do: false
 
-  def valid_format?(vat = <<country::binary-size(2), _::binary>>) do
+  def valid_format?(<<country::binary-size(2), _::binary>> = vat) do
     @regexes
     |> Map.get(country)
     |> Regex.match?(vat)

--- a/lib/ex_vatcheck/vies_client/xml_parser.ex
+++ b/lib/ex_vatcheck/vies_client/xml_parser.ex
@@ -38,7 +38,7 @@ defmodule ExVatcheck.VIESClient.XMLParser do
     ...
     <wsdl:service name="checkVatService">
       <wsdl:port name="checkVatPort" binding="impl:checkVatBinding">
-        <wsdlsoap:address location="http://ec.europa.eu/taxation_customs/vies/services/checkVatService"/>
+        <wsdlsoap:address location="https://ec.europa.eu/taxation_customs/vies/services/checkVatService"/>
       </wsdl:port>
     </wsdl:service>
   </wsdl:definitions>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExVatcheck.MixProject do
   def project do
     [
       app: :ex_vatcheck,
-      version: "0.1.4",
+      version: "0.1.5",
       elixir: "~> 1.4",
       name: "ExVatcheck",
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/test/ex_vatcheck/vies_client/xml_parser_test.exs
+++ b/test/ex_vatcheck/vies_client/xml_parser_test.exs
@@ -5,7 +5,7 @@ defmodule ExVatcheck.VIESClient.XMLParserTest do
 
   describe "parse_service/1" do
     test "parses the checkVatService url from the VIES WSDL response" do
-      url = "http://ec.europa.eu/taxation_customs/vies/services/checkVatService"
+      url = "https://ec.europa.eu/taxation_customs/vies/services/checkVatService"
 
       response = """
       <wsdl:definitions>

--- a/test/fixtures/vies_responses.ex
+++ b/test/fixtures/vies_responses.ex
@@ -4,7 +4,7 @@ defmodule Fixtures.VIESResponses do
   """
 
   def service_url do
-    "http://ec.europa.eu/taxation_customs/vies/services/checkVatService"
+    "https://ec.europa.eu/taxation_customs/vies/services/checkVatService"
   end
 
   def valid_wsdl do


### PR DESCRIPTION
We recently released an update to correct for VIES switching from http to https. 

Unfortunately, when we generate a client for VIES, VIES still sends back an invalid URL using http:
```elixir
%ExVatcheck.VIESClient{
  url: "http://ec.europa.eu/taxation_customs/vies/services/checkVatService"
}
```
This results in the XML request sent to this newly returned URL failing. To correct for this, we inspect the URL we receive back and, if present, replace `"http://"` with `"https://"`, which allows the requests to complete successfully again.

The last release relied on the test suite (which the initial fix resolved). We assumed that we could trust the information returned by the VIES client in the fixture data, which, as evidenced by this PR, wasn't entirely true. To test this manually, you can do the following on this branch:
```elixir
$ iex -S mix
iex(1)> ExVatcheck.check("FR40303265045")
%ExVatcheck.VAT{
  exists: true,
  valid: true,
  vies_available: true,
  vies_response: %{
    address: "11 RUE AMPERE\n26600 PONT DE L ISERE",
    country_code: "FR",
    name: "SA SODIMAS",
    request_date: "2020-03-19",
    valid: true,
    vat_number: "40303265045"
  }
}
```