### PR TITLE
version 0.3 - fixes breaking XML namespace parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+#### 0.3.1 (2022-08-31)
+
+##### Bug Fixes
+
+* Fixes change to business name fetched in the smoke test.
+
 #### 0.3.0 (2022-08-31)
 
 ##### Breaking Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+#### 0.3.0 (2022-08-31)
+
+##### Breaking Bug Fixes
+
+* Updates XML parsing logic to work with new VIES SOAP envelope namespace changes.
+* Better error handling if `SweetXml.xpath` returns an error and parsing fails.
+
 #### 0.2.1 (2021-10-13)
 
 ##### Chores

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ by adding `ex_vatcheck` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:ex_vatcheck, "~> 0.3.0"}
+    {:ex_vatcheck, "~> 0.3.1"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ by adding `ex_vatcheck` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:ex_vatcheck, "~> 0.1.5"}
+    {:ex_vatcheck, "~> 0.3.0"}
   ]
 end
 ```

--- a/lib/ex_vatcheck/vies_client.ex
+++ b/lib/ex_vatcheck/vies_client.ex
@@ -27,7 +27,7 @@ defmodule ExVatcheck.VIESClient do
   def check_vat(client, country_code, vat_number) do
     req_body = vat_request(country_code, vat_number)
 
-    case HTTPoison.post(client.url, req_body) do
+    case HTTPoison.post(client.url, req_body, [{"content-type", "text/xml"}]) do
       {:ok, response} -> XMLParser.parse_response(response.body)
       {:error, %HTTPoison.Error{reason: :timeout}} -> {:error, "Service timed out"}
     end

--- a/lib/ex_vatcheck/vies_client/xml_parser.ex
+++ b/lib/ex_vatcheck/vies_client/xml_parser.ex
@@ -18,16 +18,17 @@ defmodule ExVatcheck.VIESClient.XMLParser do
                            "//wsdl:definitions/wsdl:service[name=checkVatService]/wsdl:port[name=checkVatPort]/wsdlsoap:address/@location"
                          )
 
-  @check_vat_fault SweetXml.sigil_x("//soap:Envelope/soap:Body/soap:Fault/faultstring/text()")
-  @check_vat_response SweetXml.sigil_x("//soap:Envelope/soap:Body/checkVatResponse")
+  @check_vat_fault SweetXml.sigil_x("//env:Envelope/env:Body/env:Fault/faultstring/text()")
+  @check_vat_response SweetXml.sigil_x("//env:Envelope/env:Body/ns2:checkVatResponse")
+
 
   @check_vat_response_fields [
-    country_code: SweetXml.sigil_x("./countryCode/text()"),
-    vat_number: SweetXml.sigil_x("./vatNumber/text()"),
-    request_date: SweetXml.sigil_x("./requestDate/text()"),
-    valid: SweetXml.sigil_x("./valid/text()"),
-    name: SweetXml.sigil_x("./name/text()"),
-    address: SweetXml.sigil_x("./address/text()")
+    country_code: SweetXml.sigil_x("./ns2:countryCode/text()"),
+    vat_number: SweetXml.sigil_x("./ns2:vatNumber/text()"),
+    request_date: SweetXml.sigil_x("./ns2:requestDate/text()"),
+    valid: SweetXml.sigil_x("./ns2:valid/text()"),
+    name: SweetXml.sigil_x("./ns2:name/text()"),
+    address: SweetXml.sigil_x("./ns2:address/text()")
   ]
 
   @doc ~S"""
@@ -60,31 +61,31 @@ defmodule ExVatcheck.VIESClient.XMLParser do
 
   When the service is available, the response has the following structure:
   ```
-  <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-    <soap:Body>
-      <checkVatResponse xmlns="urn:ec.europa.eu:taxud:vies:services:checkVat:types">
-        <countryCode>BE</countryCode>
-        <vatNumber>0829071668</vatNumber>
-        <requestDate>2016-01-16+01:00</requestDate>
-        <valid>true</valid>
-        <name>SPRL BIGUP</name>
-        <address>RUE LONGUE 93 1320 BEAUVECHAIN</address>
-      </checkVatResponse>
-    </soap:Body>
-  </soap:Envelope>
+  <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+    <env:Body>
+      <ns2:checkVatResponse xmlns="urn:ec.europa.eu:taxud:vies:services:checkVat:types">
+        <ns2:countryCode>BE</countryCode>
+        <ns2:vatNumber>0829071668</vatNumber>
+        <ns2:requestDate>2016-01-16+01:00</requestDate>
+        <ns2:valid>true</valid>
+        <ns2:name>SPRL BIGUP</name>
+        <ns2:address>RUE LONGUE 93 1320 BEAUVECHAIN</address>
+      </ns2:checkVatResponse>
+    </env:Body>
+  </env:Envelope>
   ```
 
   Sometimes, the VIES service is unavailable (see http://ec.europa.eu/taxation_customs/vies/help.html).
   In the case that it is not, the response has the following structure:
 
   ```
-  <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-    <soap:Body>
-      <soap:Fault>
+  <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+    <env:Body>
+      <env:Fault>
         ...
-      </soap:Fault>
-    </soap:Body>
-  </soap:Envelope>
+      </env:Fault>
+    </env:Body>
+  </env:Envelope>
   ```
   """
   @spec parse_response(binary) :: {:ok, map} | {:error, binary}
@@ -93,7 +94,7 @@ defmodule ExVatcheck.VIESClient.XMLParser do
       {:error, fault |> to_string() |> format_fault()}
     else
       body = Xml.parse(response_body, @check_vat_response, @check_vat_response_fields)
-      {:ok, format_fields(body)}
+        {:ok, format_fields(body)}
     end
   end
 

--- a/lib/ex_vatcheck/xml.ex
+++ b/lib/ex_vatcheck/xml.ex
@@ -2,9 +2,23 @@ defmodule ExVatcheck.Xml do
   @moduledoc false
   require SweetXml
 
-  def parse(doc, %SweetXpath{} = spec, subspec \\ []) when is_binary(doc) do
+  def parse(doc, spec, subspec \\ [])
+
+  def parse(doc, spec, subspec) when is_binary(doc) do
     doc
     |> SweetXml.parse(dtd: :none)
-    |> SweetXml.xpath(spec, subspec)
+    |> parse(spec, subspec)
+  end
+
+  def parse(doc, %SweetXpath{} = spec, []) when is_tuple(doc) do
+    SweetXml.xpath(doc, spec)
+  end
+
+  def parse(doc, %SweetXpath{} = spec, subspec) when is_tuple(doc) do
+    if SweetXml.xpath(doc, spec) do
+      SweetXml.xpath(doc, spec, subspec)
+    else
+      nil
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExVatcheck.MixProject do
   def project do
     [
       app: :ex_vatcheck,
-      version: "0.2.1",
+      version: "0.3.0",
       elixir: "~> 1.6",
       name: "ExVatcheck",
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExVatcheck.MixProject do
   def project do
     [
       app: :ex_vatcheck,
-      version: "0.3.0",
+      version: "0.3.1",
       elixir: "~> 1.6",
       name: "ExVatcheck",
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/test/ex_vatcheck/vies_client/xml_parser_test.exs
+++ b/test/ex_vatcheck/vies_client/xml_parser_test.exs
@@ -38,18 +38,18 @@ defmodule ExVatcheck.VIESClient.XMLParserTest do
   describe "parse_response/1" do
     test "parses the XML response from the checkVatService into a map" do
       response = """
-      <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-        <soap:Body>
-          <checkVatResponse xmlns="urn:ec.europa.eu:taxud:vies:services:checkVat:types">
-            <countryCode>BE</countryCode>
-            <vatNumber>0829071668</vatNumber>
-            <requestDate>2016-01-16+01:00</requestDate>
-            <valid>true</valid>
-            <name>SPRL BIGUP</name>
-            <address>RUE LONGUE 93 1320 BEAUVECHAIN</address>
-          </checkVatResponse>
-        </soap:Body>
-      </soap:Envelope>
+      <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+        <env:Body>
+          <ns2:checkVatResponse xmlns:ns2="urn:ec.europa.eu:taxud:vies:services:checkVat:types">
+            <ns2:countryCode>BE</ns2:countryCode>
+            <ns2:vatNumber>0829071668</ns2:vatNumber>
+            <ns2:requestDate>2016-01-16+01:00</ns2:requestDate>
+            <ns2:valid>true</ns2:valid>
+            <ns2:name>SPRL BIGUP</ns2:name>
+            <ns2:address>RUE LONGUE 93 1320 BEAUVECHAIN</ns2:address>
+          </ns2:checkVatResponse>
+        </env:Body>
+      </env:Envelope>
       """
 
       expected = %{
@@ -66,18 +66,18 @@ defmodule ExVatcheck.VIESClient.XMLParserTest do
 
     test "parses the XML response for invalid VAT identifcation number" do
       response = """
-      <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-        <soap:Body>
-          <checkVatResponse xmlns="urn:ec.europa.eu:taxud:vies:services:checkVat:types">
-            <countryCode>BE</countryCode>
-            <vatNumber>123123123</vatNumber>
-            <requestDate>2016-01-16+01:00</requestDate>
-            <valid>false</valid>
-            <name>---</name>
-            <address>---</address>
-          </checkVatResponse>
-        </soap:Body>
-      </soap:Envelope>
+      <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+        <env:Body>
+          <ns2:checkVatResponse xmlns:ns2="urn:ec.europa.eu:taxud:vies:services:checkVat:types">
+            <ns2:countryCode>BE</ns2:countryCode>
+            <ns2:vatNumber>123123123</ns2:vatNumber>
+            <ns2:requestDate>2016-01-16+01:00</ns2:requestDate>
+            <ns2:valid>false</ns2:valid>
+            <ns2:name>---</ns2:name>
+            <ns2:address>---</ns2:address>
+          </ns2:checkVatResponse>
+        </env:Body>
+      </env:Envelope>
       """
 
       expected = %{
@@ -94,18 +94,18 @@ defmodule ExVatcheck.VIESClient.XMLParserTest do
 
     test "correctly keeps nil values when present in checkVat response" do
       response = """
-      <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-        <soap:Body>
-          <checkVatResponse xmlns="urn:ec.europa.eu:taxud:vies:services:checkVat:types">
-            <countryCode>BG</countryCode>
-            <vatNumber>451158821</vatNumber>
-            <requestDate>2016-01-16+01:00</requestDate>
-            <valid>false</valid>
-            <name></name>
-            <address></address>
-          </checkVatResponse>
-        </soap:Body>
-      </soap:Envelope>
+      <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+        <env:Body>
+          <ns2:checkVatResponse xmlns:ns2="urn:ec.europa.eu:taxud:vies:services:checkVat:types">
+            <ns2:countryCode>BG</ns2:countryCode>
+            <ns2:vatNumber>451158821</ns2:vatNumber>
+            <ns2:requestDate>2016-01-16+01:00</ns2:requestDate>
+            <ns2:valid>false</ns2:valid>
+            <ns2:name></ns2:name>
+            <ns2:address></ns2:address>
+          </ns2:checkVatResponse>
+        </env:Body>
+      </env:Envelope>
       """
 
       expected = %{
@@ -122,18 +122,18 @@ defmodule ExVatcheck.VIESClient.XMLParserTest do
 
     test "gracefully handles unexpected date formats" do
       response = """
-      <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-        <soap:Body>
-          <checkVatResponse xmlns="urn:ec.europa.eu:taxud:vies:services:checkVat:types">
-            <countryCode>BG</countryCode>
-            <vatNumber>451158821</vatNumber>
-            <requestDate>2016-01</requestDate>
-            <valid>false</valid>
-            <name></name>
-            <address></address>
-          </checkVatResponse>
-        </soap:Body>
-      </soap:Envelope>
+      <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+        <env:Body>
+          <ns2:checkVatResponse xmlns:ns2="urn:ec.europa.eu:taxud:vies:services:checkVat:types">
+            <ns2:countryCode>BG</ns2:countryCode>
+            <ns2:vatNumber>451158821</ns2:vatNumber>
+            <ns2:requestDate>2016-01</ns2:requestDate>
+            <ns2:valid>false</ns2:valid>
+            <ns2:name></ns2:name>
+            <ns2:address></ns2:address>
+          </ns2:checkVatResponse>
+        </env:Body>
+      </env:Envelope>
       """
 
       expected = %{
@@ -150,13 +150,13 @@ defmodule ExVatcheck.VIESClient.XMLParserTest do
 
     test "gracefully handles when VIES service unavailable" do
       fault = """
-        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-          <soap:Body>
-            <soap:Fault>
+        <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+          <env:Body>
+            <env:Fault>
               <faultstring>MS_UNAVAILABLE</faultstring>
-            </soap:Fault>
-          </soap:Body>
-        </soap:Envelope>
+            </env:Fault>
+          </env:Body>
+        </env:Envelope>
       """
 
       assert XMLParser.parse_response(fault) == {:error, "Service unavailable"}
@@ -164,13 +164,13 @@ defmodule ExVatcheck.VIESClient.XMLParserTest do
 
     test "gracefully handles unexpected errors from the VIES service" do
       fault = """
-        <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-          <soap:Body>
-            <soap:Fault>
+        <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+          <env:Body>
+            <env:Fault>
               <faultstring>XML_ERROR</faultstring>
-            </soap:Fault>
-          </soap:Body>
-        </soap:Envelope>
+            </env:Fault>
+          </env:Body>
+        </env:Envelope>
       """
 
       assert XMLParser.parse_response(fault) == {:error, "Unknown error: XML_ERROR"}

--- a/test/ex_vatcheck/vies_client/xml_parser_test.exs
+++ b/test/ex_vatcheck/vies_client/xml_parser_test.exs
@@ -167,13 +167,33 @@ defmodule ExVatcheck.VIESClient.XMLParserTest do
         <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
           <env:Body>
             <env:Fault>
-              <faultstring>XML_ERROR</faultstring>
+              <faultstring>UNKNOWN_ERROR</faultstring>
             </env:Fault>
           </env:Body>
         </env:Envelope>
       """
 
-      assert XMLParser.parse_response(fault) == {:error, "Unknown error: XML_ERROR"}
+      assert XMLParser.parse_response(fault) == {:error, "Unknown error: UNKNOWN_ERROR"}
+    end
+
+    test "gracefully handles unexpected XML parsing errors from the VIES service" do
+      unexpected_namespaces = """
+        <soap:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+          <soap:Body>
+            <ns1:checkVatResponse xmlns:ns1="urn:ec.europa.eu:taxud:vies:services:checkVat:types">
+              <ns1:countryCode>BG</ns1:countryCode>
+              <ns1:vatNumber>451158821</ns1:vatNumber>
+              <ns1:requestDate>2016-01</ns1:requestDate>
+              <ns1:valid>false</ns1:valid>
+              <ns1:name></ns1:name>
+              <ns1:address></ns1:address>
+            </ns1:checkVatResponse>
+          </soap:Body>
+        </soap:Envelope>
+      """
+
+      assert XMLParser.parse_response(unexpected_namespaces) ==
+               {:error, "Unknown error: XML_ERROR"}
     end
   end
 end

--- a/test/ex_vatcheck/vies_client_test.exs
+++ b/test/ex_vatcheck/vies_client_test.exs
@@ -55,7 +55,7 @@ defmodule ExVatcheck.VIESClientTest do
         address: "BC0 B1 D1 BROADCAST CENTRE\nWHITE CITY PLACE\n201 WOOD LANE\nLONDON\n\nW12 7TP"
       }
 
-      stub(HTTPoison, :post, fn _, _ ->
+      stub(HTTPoison, :post, fn _, _, _ ->
         {:ok, %HTTPoison.Response{body: VIESResponses.valid_vat_response()}}
       end)
 
@@ -74,7 +74,7 @@ defmodule ExVatcheck.VIESClientTest do
         address: "---"
       }
 
-      stub(HTTPoison, :post, fn _, _ ->
+      stub(HTTPoison, :post, fn _, _, _ ->
         {:ok, %HTTPoison.Response{body: VIESResponses.invalid_vat_response()}}
       end)
 
@@ -84,7 +84,7 @@ defmodule ExVatcheck.VIESClientTest do
     test "gracefully handles error due to unavailable VIES service" do
       client = %VIESClient{url: VIESResponses.service_url()}
 
-      stub(HTTPoison, :post, fn _, _ ->
+      stub(HTTPoison, :post, fn _, _, _ ->
         {:ok, %HTTPoison.Response{body: VIESResponses.service_unavailable_response()}}
       end)
 
@@ -94,7 +94,7 @@ defmodule ExVatcheck.VIESClientTest do
     test "gracefully handles VIES service timeouts" do
       client = %VIESClient{url: VIESResponses.service_url()}
 
-      stub(HTTPoison, :post, fn _, _ ->
+      stub(HTTPoison, :post, fn _, _, _ ->
         {:error, %HTTPoison.Error{id: nil, reason: :timeout}}
       end)
 

--- a/test/ex_vatcheck/vies_client_test.exs
+++ b/test/ex_vatcheck/vies_client_test.exs
@@ -67,7 +67,7 @@ defmodule ExVatcheck.VIESClientTest do
 
       expected = %{
         country_code: "GB",
-        vat_number: "123123123",
+        vat_number: nil,
         request_date: "2016-01-16",
         valid: false,
         name: "---",

--- a/test/ex_vatcheck/vies_client_test.exs
+++ b/test/ex_vatcheck/vies_client_test.exs
@@ -81,6 +81,16 @@ defmodule ExVatcheck.VIESClientTest do
       assert VIESClient.check_vat(client, "GB", "123123123") == {:ok, expected}
     end
 
+    test "handles invalid VAT response if ExVatcheck validation misses it" do
+      client = %VIESClient{url: VIESResponses.service_url()}
+
+      stub(HTTPoison, :post, fn _, _, _ ->
+        {:ok, %HTTPoison.Response{body: VIESResponses.invalid_input_fault_response()}}
+      end)
+
+      assert VIESClient.check_vat(client, "ZZ", "123") == {:error, "Unknown error: INVALID_INPUT"}
+    end
+
     test "gracefully handles error due to unavailable VIES service" do
       client = %VIESClient{url: VIESResponses.service_url()}
 

--- a/test/ex_vatcheck_test.exs
+++ b/test/ex_vatcheck_test.exs
@@ -36,7 +36,7 @@ defmodule ExVatcheckTest do
         vies_response: @valid_vat_response
       }
 
-      stub(HTTPoison, :post, fn _, _ ->
+      stub(HTTPoison, :post, fn _, _, _ ->
         {:ok, %HTTPoison.Response{body: VIESResponses.valid_vat_response()}}
       end)
 
@@ -51,7 +51,7 @@ defmodule ExVatcheckTest do
         vies_response: @invalid_vat_response
       }
 
-      stub(HTTPoison, :post, fn _, _ ->
+      stub(HTTPoison, :post, fn _, _, _ ->
         {:ok, %HTTPoison.Response{body: VIESResponses.invalid_vat_response()}}
       end)
 
@@ -66,7 +66,7 @@ defmodule ExVatcheckTest do
         vies_response: %{error: "Service timed out"}
       }
 
-      stub(HTTPoison, :post, fn _, _ ->
+      stub(HTTPoison, :post, fn _, _, _ ->
         {:error, %HTTPoison.Error{reason: :timeout}}
       end)
 
@@ -85,7 +85,7 @@ defmodule ExVatcheckTest do
         vies_response: @invalid_vat_response
       }
 
-      stub(HTTPoison, :post, fn _, _ ->
+      stub(HTTPoison, :post, fn _, _, _ ->
         {:ok, %HTTPoison.Response{body: VIESResponses.invalid_vat_response()}}
       end)
 

--- a/test/ex_vatcheck_test.exs
+++ b/test/ex_vatcheck_test.exs
@@ -101,7 +101,7 @@ defmodule ExVatcheckTest do
                vies_response: %{
                  address: "Tobelbader Straße 30\nAT-8141 Premstätten",
                  country_code: "AT",
-                 name: "ams AG",
+                 name: "ams-OSRAM AG",
                  request_date: _date,
                  valid: true,
                  vat_number: "U28560205"

--- a/test/ex_vatcheck_test.exs
+++ b/test/ex_vatcheck_test.exs
@@ -18,7 +18,7 @@ defmodule ExVatcheckTest do
 
   @invalid_vat_response %{
     country_code: "GB",
-    vat_number: "123123123",
+    vat_number: nil,
     request_date: "2016-01-16",
     valid: false,
     name: "---",

--- a/test/fixtures/vies_responses.ex
+++ b/test/fixtures/vies_responses.ex
@@ -59,6 +59,20 @@ defmodule Fixtures.VIESResponses do
     """
   end
 
+  def invalid_input_fault_response do
+    """
+    <env:Envelope xmlns:env=\"http://schemas.xmlsoap.org/soap/envelope/\">
+      <env:Header/>
+      <env:Body>
+        <env:Fault>
+          <faultcode>env:Server</faultcode>
+          <faultstring>INVALID_INPUT</faultstring>
+        </env:Fault>
+      </env:Body>
+    </env:Envelope>
+    """
+  end
+
   def service_unavailable_response do
     """
     <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">

--- a/test/fixtures/vies_responses.ex
+++ b/test/fixtures/vies_responses.ex
@@ -25,47 +25,50 @@ defmodule Fixtures.VIESResponses do
 
   def valid_vat_response do
     """
-    <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-      <soap:Body>
-        <checkVatResponse xmlns="urn:ec.europa.eu:taxud:vies:services:checkVat:types">
-          <countryCode>GB</countryCode>
-          <vatNumber>333289454</vatNumber>
-          <requestDate>2016-01-16+01:00</requestDate>
-          <valid>true</valid>
-          <name>BRITISH BROADCASTING CORPORATION</name>
-          <address>BC0 B1 D1 BROADCAST CENTRE\nWHITE CITY PLACE\n201 WOOD LANE\nLONDON\n\nW12 7TP</address>
-        </checkVatResponse>
-      </soap:Body>
-    </soap:Envelope>
+    <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+      <env:Header/>
+      <env:Body>
+        <ns2:checkVatResponse xmlns:ns2="urn:ec.europa.eu:taxud:vies:services:checkVat:types">
+          <ns2:countryCode>GB</ns2:countryCode>
+          <ns2:vatNumber>333289454</ns2:vatNumber>
+          <ns2:requestDate>2016-01-16+01:00</ns2:requestDate>
+          <ns2:valid>true</ns2:valid>
+          <ns2:name>BRITISH BROADCASTING CORPORATION</ns2:name>
+          <ns2:address>BC0 B1 D1 BROADCAST CENTRE\nWHITE CITY PLACE\n201 WOOD LANE\nLONDON\n\nW12 7TP</ns2:address>
+        </ns2:checkVatResponse>
+      </env:Body>
+    </env:Envelope>
     """
   end
 
   def invalid_vat_response do
     """
-    <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-      <soap:Body>
-        <checkVatResponse xmlns="urn:ec.europa.eu:taxud:vies:services:checkVat:types">
-          <countryCode>GB</countryCode>
-          <vatNumber>123123123</vatNumber>
-          <requestDate>2016-01-16+01:00</requestDate>
-          <valid>false</valid>
-          <name>---</name>
-          <address>---</address>
-        </checkVatResponse>
-      </soap:Body>
-    </soap:Envelope>
+    <env:Envelope xmlns:env=\"http://schemas.xmlsoap.org/soap/envelope/\">
+      <env:Header/>
+      <env:Body>
+        <ns2:checkVatResponse xmlns:ns2=\"urn:ec.europa.eu:taxud:vies:services:checkVat:types\">
+          <ns2:countryCode>GB</ns2:countryCode>
+          <ns2:vatNumber></ns2:vatNumber>
+          <ns2:requestDate>2016-01-16+00:00</ns2:requestDate>
+          <ns2:valid>false</ns2:valid>
+          <ns2:name>---</ns2:name>
+          <ns2:address>---</ns2:address>
+        </ns2:checkVatResponse>
+      </env:Body>
+    </env:Envelope>
     """
   end
 
   def service_unavailable_response do
     """
-    <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-      <soap:Body>
-        <soap:Fault>
+    <env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/">
+      <env:Header/>
+      <env:Body>
+        <env:Fault>
           <faultstring>MS_UNAVAILABLE</faultstring>
-        </soap:Fault>
-      </soap:Body>
-    </soap:Envelope>
+        </env:Fault>
+      </env:Body>
+    </env:Envelope>
     """
   end
 end


### PR DESCRIPTION
It appears as if VIES changed their SOAP envelope XML prefixes in their responses without any formal announcement. [Here's a recent Stack Overflow article of other people uncovering this issue.](https://stackoverflow.com/questions/73443655/why-does-this-vat-number-validation-script-return-an-error/73486762)

This new version fixes a few things:
- explicitly passes a `content-type` header when POSTing to VIES
- changes the XML namespace prefixes so `xpath` can correctly access values (also updates fixtures with new responses)
- adds better handling when `SweetXml` is errors during `xpath` calls